### PR TITLE
Add `aria-label` for GH icon

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,6 +22,7 @@ website:
     right:
       - icon: github
         href: https://github.com/tidymodels/vetiver.rstudio.com
+        aria-label: Vetiver site GitHub
 
   navbar:
     background: primary


### PR DESCRIPTION
* Adds `aria-label` for GH icon in navbar
* Fixes #9
* n.b. I wrote "Vetiver site," since it won't direct to the GH repo for vetiver itself